### PR TITLE
Run the SDK word count example with the SparkPipelineRunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,21 @@ would do the following:
     options.setSparkMaster("spark://host:port");
     EvaluationResult result = SparkPipelineRunner.create(options).run(p);
 
+## Word Count Example
+
+First download a text document to use as input:
+
+    curl http://www.gutenberg.org/cache/epub/1128/pg1128.txt > /tmp/kinglear.txt
+
+Then run the [word count example][wc] from the SDK using a single threaded Spark instance
+in local mode:
+
+    mvn exec:exec -Dclass=com.google.cloud.dataflow.examples.WordCount \
+      -Dinput=/tmp/kinglear.txt -Doutput=/tmp/out -Drunner=SparkPipelineRunner \
+      -DsparkMaster=local
+
+Check the output by running:
+
+    head /tmp/out/part-00000
+
+[wc]: https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/WordCount.java

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,11 @@ License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.7</java.version>
+        <class>com.google.cloud.dataflow.examples.WordCount</class>
+        <input>/tmp/kinglear.txt</input>
+        <output>/tmp/out</output>
+        <runner>SparkPipelineRunner</runner>
+        <sparkMaster>local</sparkMaster>
     </properties>
 
     <build>
@@ -171,6 +176,23 @@ License.
                         </excludes>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>1.2.1</version>
+                    <configuration>
+                        <executable>java</executable>
+                        <arguments>
+                            <argument>-classpath</argument>
+                            <classpath />
+                            <argument>${class}</argument>
+                            <argument>--input=${input}</argument>
+                            <argument>--output=${output}</argument>
+                            <argument>--runner=${runner}</argument>
+                            <argument>--sparkMaster=${sparkMaster}</argument>
+                        </arguments>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -203,6 +225,11 @@ License.
         <dependency>
             <groupId>com.google.cloud.dataflow</groupId>
             <artifactId>google-cloud-dataflow-java-sdk-all</artifactId>
+            <version>0.3.150326</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud.dataflow</groupId>
+            <artifactId>google-cloud-dataflow-java-examples-all</artifactId>
             <version>0.3.150326</version>
         </dependency>
         <dependency>

--- a/src/main/java/com/cloudera/dataflow/spark/SparkPipelineOptionsRegistrar.java
+++ b/src/main/java/com/cloudera/dataflow/spark/SparkPipelineOptionsRegistrar.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2014, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.cloudera.dataflow.spark;
+
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.options.PipelineOptionsRegistrar;
+import com.google.common.collect.ImmutableList;
+
+public class SparkPipelineOptionsRegistrar implements PipelineOptionsRegistrar {
+  @Override
+  public Iterable<Class<? extends PipelineOptions>> getPipelineOptions() {
+    return ImmutableList.<Class<? extends PipelineOptions>>of(SparkPipelineOptions.class);
+  }
+}

--- a/src/main/java/com/cloudera/dataflow/spark/SparkPipelineRunner.java
+++ b/src/main/java/com/cloudera/dataflow/spark/SparkPipelineRunner.java
@@ -16,6 +16,9 @@
 package com.cloudera.dataflow.spark;
 
 import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.options.DirectPipelineOptions;
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.options.PipelineOptionsValidator;
 import com.google.cloud.dataflow.sdk.runners.PipelineRunner;
 import com.google.cloud.dataflow.sdk.runners.TransformTreeNode;
 import com.google.cloud.dataflow.sdk.transforms.PTransform;
@@ -76,6 +79,14 @@ public class SparkPipelineRunner extends PipelineRunner<EvaluationResult> {
     return new SparkPipelineRunner(options);
   }
 
+  /**
+   * Constructs a SparkPipelineRunner from the given options.
+   */
+  public static SparkPipelineRunner fromOptions(PipelineOptions options) {
+    SparkPipelineOptions sparkOptions =
+        PipelineOptionsValidator.validate(SparkPipelineOptions.class, options);
+    return new SparkPipelineRunner(sparkOptions);
+  }
 
   /**
    * No parameter constructor defaults to running this pipeline in Spark's local mode, in a single

--- a/src/main/java/com/cloudera/dataflow/spark/SparkPipelineRunnerRegistrar.java
+++ b/src/main/java/com/cloudera/dataflow/spark/SparkPipelineRunnerRegistrar.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2014, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.cloudera.dataflow.spark;
+
+import com.google.cloud.dataflow.sdk.runners.PipelineRunner;
+import com.google.cloud.dataflow.sdk.runners.PipelineRunnerRegistrar;
+import com.google.common.collect.ImmutableList;
+
+public class SparkPipelineRunnerRegistrar implements PipelineRunnerRegistrar {
+  @Override
+  public Iterable<Class<? extends PipelineRunner<?>>> getPipelineRunners() {
+    return ImmutableList.<Class<? extends PipelineRunner<?>>>of(SparkPipelineRunner.class);
+  }
+}

--- a/src/main/resources/META-INF/services/com.google.cloud.dataflow.sdk.options.PipelineOptionsRegistrar
+++ b/src/main/resources/META-INF/services/com.google.cloud.dataflow.sdk.options.PipelineOptionsRegistrar
@@ -1,0 +1,16 @@
+#
+# Copyright 2014 Cloudera Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.cloudera.dataflow.spark.SparkPipelineOptionsRegistrar

--- a/src/main/resources/META-INF/services/com.google.cloud.dataflow.sdk.runners.PipelineRunnerRegistrar
+++ b/src/main/resources/META-INF/services/com.google.cloud.dataflow.sdk.runners.PipelineRunnerRegistrar
@@ -1,0 +1,16 @@
+#
+# Copyright 2014 Cloudera Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.cloudera.dataflow.spark.SparkPipelineRunnerRegistrar


### PR DESCRIPTION
With this change it's now possible to run the SDK word count example unchanged on local Spark. Running on a cluster will require more work to get the correct JARs on the classpath, so that can be tackled separately.

This addresses https://github.com/cloudera/spark-dataflow/issues/27 for the local case.