### PR TITLE
Document how to run on a cluster with spark-submit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,31 @@ Check the output by running:
 
     head /tmp/out/part-00000
 
+__Note: running examples using `mvn exec:exec` only works for Spark local mode at the
+moment. See the next section for how to run on a cluster.__
+
 [wc]: https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/WordCount.java
+
+## Running on a Cluster
+
+Spark Dataflow pipelines can be run on a cluster using the `spark-submit` command.
+
+First copy a text document to HDFS:
+
+    curl http://www.gutenberg.org/cache/epub/1128/pg1128.txt | hadoop fs -put - kinglear.txt
+
+Then run the word count example using Spark submit with the `yarn-client` master
+(`yarn-cluster` works just as well):
+
+    spark-submit \
+      --class com.google.cloud.dataflow.examples.WordCount \
+      --master yarn-client \
+      target/spark-dataflow-*-spark-app.jar \
+        --input=kinglear.txt --output=out --runner=SparkPipelineRunner --sparkMaster=yarn-client
+
+Check the output by running:
+
+    hadoop fs -tail out/part-00000
 
 [![Build Status](https://travis-ci.org/cloudera/spark-dataflow.png?branch=master)](https://travis-ci.org/cloudera/spark-dataflow)
 [![codecov.io](https://codecov.io/github/cloudera/spark-dataflow/coverage.svg?branch=master)](https://codecov.io/github/cloudera/spark-dataflow?branch=master)

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,33 @@ License.
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>2.3</version>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>shade</goal>
+                            </goals>
+                            <configuration>
+                                <relocations>
+                                    <!-- relocate Guava used by Dataflow (v18) since it conflicts with version used by Hadoop (v11) -->
+                                    <relocation>
+                                        <pattern>com.google.common</pattern>
+                                        <shadedPattern>com.cloudera.dataflow.spark.relocated.com.google.common</shadedPattern>
+                                    </relocation>
+                                </relocations>
+                                <shadedArtifactAttached>true</shadedArtifactAttached>
+                                <shadedClassifierName>spark-app</shadedClassifierName>
+                                <transformers>
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                </transformers>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -242,6 +269,10 @@ License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 
@@ -250,14 +281,7 @@ License.
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.10</artifactId>
             <version>${spark.version}</version>
-            <exclusions>
-                <!-- JUL is used by Google Dataflow as the backend logger, so exclude
-                 jul-to-slf4j to avoid a loop -->
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>jul-to-slf4j</artifactId>
-                </exclusion>
-            </exclusions>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -268,11 +292,25 @@ License.
             <groupId>com.google.cloud.dataflow</groupId>
             <artifactId>google-cloud-dataflow-java-sdk-all</artifactId>
             <version>0.4.150414</version>
+            <exclusions>
+                <!-- Use Hadoop/Spark's backend logger -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-jdk14</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.dataflow</groupId>
             <artifactId>google-cloud-dataflow-java-examples-all</artifactId>
             <version>0.4.150414</version>
+            <exclusions>
+                <!-- Use Hadoop/Spark's backend logger -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-jdk14</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
This change creates a Spark application JAR that can be used to
run the word count example on the cluster.  The Spark depdendency
is now marked 'provided' to make it possible to run on different
(minor) versions of Spark.

Note also that Guava is shaded in the application JAR to avoid
conflicts with the version used by Hadoop.