### PR TITLE
Compute PCollections that are created only for their side effects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,12 @@ License.
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <reporting>

--- a/src/main/java/com/cloudera/dataflow/spark/SparkPipelineRunner.java
+++ b/src/main/java/com/cloudera/dataflow/spark/SparkPipelineRunner.java
@@ -101,9 +101,15 @@ public final class SparkPipelineRunner extends PipelineRunner<EvaluationResult> 
 
   @Override
   public EvaluationResult run(Pipeline pipeline) {
+    LOG.info("Executing pipeline using the SparkPipelineRunner.");
+
     JavaSparkContext jsc = getContext();
     EvaluationContext ctxt = new EvaluationContext(jsc, pipeline);
     pipeline.traverseTopologically(new Evaluator(ctxt));
+    ctxt.computeOutputs();
+
+    LOG.info("Pipeline execution complete.");
+
     return ctxt;
   }
 

--- a/src/test/java/com/cloudera/dataflow/spark/SerializationTest.java
+++ b/src/test/java/com/cloudera/dataflow/spark/SerializationTest.java
@@ -44,9 +44,25 @@ public class SerializationTest {
 
   public static class StringHolder { // not serializable
     private String string;
+
     public StringHolder(String string) {
       this.string = string;
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      StringHolder that = (StringHolder) o;
+      return string.equals(that.string);
+    }
+
+    @Override
+    public int hashCode() {
+      return string.hashCode();
+    }
+
     @Override
     public String toString() {
       return string;

--- a/src/test/java/com/cloudera/dataflow/spark/SideEffectsTest.java
+++ b/src/test/java/com/cloudera/dataflow/spark/SideEffectsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.cloudera.dataflow.spark;
+
+import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.coders.StringDelegateCoder;
+import com.google.cloud.dataflow.sdk.transforms.Create;
+import com.google.cloud.dataflow.sdk.transforms.DoFn;
+import com.google.cloud.dataflow.sdk.transforms.ParDo;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import java.io.Serializable;
+import java.net.URI;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class SideEffectsTest implements Serializable {
+  @Test
+  public void test() throws Exception {
+    SparkPipelineOptions options = SparkPipelineOptionsFactory.create();
+    options.setRunner(SparkPipelineRunner.class);
+    Pipeline pipeline = Pipeline.create(options);
+
+    pipeline.getCoderRegistry().registerCoder(URI.class, StringDelegateCoder.of(URI.class));
+
+    PCollection<String> strings = pipeline.apply(Create.of("a"));
+    PCollection<String> output = strings.apply(ParDo.of(new DoFn<String, String>() {
+      @Override
+      public void processElement(ProcessContext c) throws Exception {
+        throw new IllegalStateException("Side effect");
+      }
+    }));
+
+    try {
+      pipeline.run();
+      fail("Run should thrown an exception");
+    } catch (Exception e) {
+      // expected
+      e.printStackTrace();
+    }
+  }
+}


### PR DESCRIPTION
This is a difference between Dataflow and Spark: in Spark RDDs that have no action performed on them will not be computed, while in Dataflow they will be computed (for their side-effects).

This is taken advantage of by DataflowAssert, which is used in tests to perform assertions on PCollections. Currently some failures are being masked in Spark Dataflow (e.g. SerializationTest) since the assertions are never being run because Spark doesn't compute the RDD.

The fix is to track which RDDs are not computed and explicitly compute them.