### PR TITLE
Allow tests to share a single Spark context.

### DIFF
--- a/src/main/java/com/cloudera/dataflow/spark/EvaluationContext.java
+++ b/src/main/java/com/cloudera/dataflow/spark/EvaluationContext.java
@@ -168,7 +168,7 @@ public class EvaluationContext implements EvaluationResult {
 
   @Override
   public void close() {
-    jsc.stop();
+    SparkContextFactory.stopSparkContext(jsc);
   }
 
   @Override

--- a/src/main/java/com/cloudera/dataflow/spark/SparkContextFactory.java
+++ b/src/main/java/com/cloudera/dataflow/spark/SparkContextFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.cloudera.dataflow.spark;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.serializer.KryoSerializer;
+
+final class SparkContextFactory {
+
+  /**
+   * If the property <code>dataflow.spark.test.reuseSparkContext</code> is set to
+   * <code>true</code> then the Spark context will be reused for dataflow pipelines.
+   * This property should only be enabled for tests.
+   */
+  public static final String TEST_REUSE_SPARK_CONTEXT =
+      "dataflow.spark.test.reuseSparkContext";
+  private static JavaSparkContext sparkContext;
+  private static String sparkMaster;
+
+  private SparkContextFactory() {
+  }
+
+  public static synchronized JavaSparkContext getSparkContext(String master) {
+    if (Boolean.getBoolean(TEST_REUSE_SPARK_CONTEXT)) {
+      if (sparkContext == null) {
+        sparkContext = createSparkContext(master);
+        sparkMaster = master;
+      } else if (!master.equals(sparkMaster)) {
+        throw new IllegalArgumentException(String.format("Cannot reuse spark context " +
+                "with different spark master URL. Existing: %s, requested: %s.",
+            sparkMaster, master));
+      }
+      return sparkContext;
+    } else {
+      return createSparkContext(master);
+    }
+  }
+
+  public static synchronized void stopSparkContext(JavaSparkContext context) {
+    if (!Boolean.getBoolean(TEST_REUSE_SPARK_CONTEXT)) {
+      context.stop();
+    }
+  }
+
+  private static JavaSparkContext createSparkContext(String master) {
+    SparkConf conf = new SparkConf();
+    conf.setMaster(master);
+    conf.setAppName("spark pipeline job");
+    conf.set("spark.serializer", KryoSerializer.class.getCanonicalName());
+    return new JavaSparkContext(conf);
+  }
+}

--- a/src/main/java/com/cloudera/dataflow/spark/SparkPipelineRunner.java
+++ b/src/main/java/com/cloudera/dataflow/spark/SparkPipelineRunner.java
@@ -22,9 +22,7 @@ import com.google.cloud.dataflow.sdk.runners.PipelineRunner;
 import com.google.cloud.dataflow.sdk.runners.TransformTreeNode;
 import com.google.cloud.dataflow.sdk.transforms.PTransform;
 import com.google.cloud.dataflow.sdk.values.PValue;
-import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.serializer.KryoSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,7 +102,7 @@ public final class SparkPipelineRunner extends PipelineRunner<EvaluationResult> 
     try {
       LOG.info("Executing pipeline using the SparkPipelineRunner.");
 
-      JavaSparkContext jsc = getContext();
+      JavaSparkContext jsc = SparkContextFactory.getSparkContext(mOptions.getSparkMaster());
       EvaluationContext ctxt = new EvaluationContext(jsc, pipeline);
       pipeline.traverseTopologically(new Evaluator(ctxt));
       ctxt.computeOutputs();
@@ -115,14 +113,6 @@ public final class SparkPipelineRunner extends PipelineRunner<EvaluationResult> 
     } catch (Exception e) {
       throw new RuntimeException(e); // wrap a SparkException in a RuntimeException
     }
-  }
-
-  private JavaSparkContext getContext() {
-    SparkConf conf = new SparkConf();
-    conf.setMaster(mOptions.getSparkMaster());
-    conf.setAppName("spark pipeline job");
-    conf.set("spark.serializer", KryoSerializer.class.getCanonicalName());
-    return new JavaSparkContext(conf);
   }
 
   private static final class Evaluator implements Pipeline.PipelineVisitor {

--- a/src/test/java/com/cloudera/dataflow/spark/AvroPipelineTest.java
+++ b/src/test/java/com/cloudera/dataflow/spark/AvroPipelineTest.java
@@ -67,7 +67,8 @@ public class AvroPipelineTest {
     PCollection<GenericRecord> input = p.apply(
         AvroIO.Read.from(inputFile.getAbsolutePath()).withSchema(schema));
     input.apply(AvroIO.Write.to(outputDir.getAbsolutePath()).withSchema(schema));
-    SparkPipelineRunner.create().run(p);
+    EvaluationResult res = SparkPipelineRunner.create().run(p);
+    res.close();
 
     List<GenericRecord> records = readGenericFile();
     assertEquals(Lists.newArrayList(savedRecord), records);

--- a/src/test/java/com/cloudera/dataflow/spark/DeDupTest.java
+++ b/src/test/java/com/cloudera/dataflow/spark/DeDupTest.java
@@ -49,6 +49,7 @@ public class DeDupTest {
 
     DataflowAssert.that(output).containsInAnyOrder(EXPECTED_SET);
 
-    p.run();
+    EvaluationResult res = SparkPipelineRunner.create().run(p);
+    res.close();
   }
 }

--- a/src/test/java/com/cloudera/dataflow/spark/EmptyInputTest.java
+++ b/src/test/java/com/cloudera/dataflow/spark/EmptyInputTest.java
@@ -38,8 +38,9 @@ public class EmptyInputTest {
     PCollection<String> inputWords = p.apply(Create.of(empty)).setCoder(StringUtf8Coder.of());
     PCollection<String> output = inputWords.apply(Combine.globally(new ConcatWords()));
 
-    EvaluationResult run = SparkPipelineRunner.create(options).run(p);
-    assertEquals("", Iterables.getOnlyElement(run.get(output)));
+    EvaluationResult res = SparkPipelineRunner.create().run(p);
+    assertEquals("", Iterables.getOnlyElement(res.get(output)));
+    res.close();
   }
 
   public static class ConcatWords implements SerializableFunction<Iterable<String>, String> {

--- a/src/test/java/com/cloudera/dataflow/spark/HadoopFileFormatPipelineTest.java
+++ b/src/test/java/com/cloudera/dataflow/spark/HadoopFileFormatPipelineTest.java
@@ -70,7 +70,8 @@ public class HadoopFileFormatPipelineTest {
             .withValueClass(Text.class));
     input.apply(ParDo.of(new TabSeparatedString()))
         .apply(TextIO.Write.to(outputFile.getAbsolutePath()).withoutSharding());
-    SparkPipelineRunner.create().run(p);
+    EvaluationResult res = SparkPipelineRunner.create().run(p);
+    res.close();
 
     List<String> records = Files.readLines(outputFile, Charsets.UTF_8);
     for (int i = 0; i < 5; i++) {

--- a/src/test/java/com/cloudera/dataflow/spark/NumShardsTest.java
+++ b/src/test/java/com/cloudera/dataflow/spark/NumShardsTest.java
@@ -64,7 +64,8 @@ public class NumShardsTest {
     PCollection<String> inputWords = p.apply(Create.of(WORDS)).setCoder(StringUtf8Coder.of());
     PCollection<String> output = inputWords.apply(new WordCount.CountWords());
     output.apply(TextIO.Write.to(outputDir.getAbsolutePath()).withNumShards(3).withSuffix(".txt"));
-    p.run();
+    EvaluationResult res = SparkPipelineRunner.create().run(p);
+    res.close();
 
     int count = 0;
     Set<String> expected = Sets.newHashSet("hi: 5", "there: 1", "sue: 2", "bob: 2");

--- a/src/test/java/com/cloudera/dataflow/spark/SerializationTest.java
+++ b/src/test/java/com/cloudera/dataflow/spark/SerializationTest.java
@@ -123,8 +123,8 @@ public class SerializationTest {
 
     DataflowAssert.that(output).containsInAnyOrder(EXPECTED_COUNT_SET);
 
-    p.run();
-
+    EvaluationResult res = SparkPipelineRunner.create().run(p);
+    res.close();
   }
 
   /**

--- a/src/test/java/com/cloudera/dataflow/spark/SimpleWordCountTest.java
+++ b/src/test/java/com/cloudera/dataflow/spark/SimpleWordCountTest.java
@@ -52,8 +52,8 @@ public class SimpleWordCountTest {
 
     DataflowAssert.that(output).containsInAnyOrder(EXPECTED_COUNT_SET);
 
-    p.run();
-
+    EvaluationResult res = SparkPipelineRunner.create().run(p);
+    res.close();
   }
 
   /**

--- a/src/test/java/com/cloudera/dataflow/spark/TfIdfTest.java
+++ b/src/test/java/com/cloudera/dataflow/spark/TfIdfTest.java
@@ -98,7 +98,8 @@ public class TfIdfTest {
         .apply(new ComputeTfIdf())
         .apply(new WriteTfIdf(outputDir.toURI().toString()));
 
-    SparkPipelineRunner.create().run(pipeline);
+    EvaluationResult res = SparkPipelineRunner.create().run(pipeline);
+    res.close();
 
     for (File f : tmpDir.getRoot().listFiles(new FileFilter() {
       @Override


### PR DESCRIPTION
It's not possible to have multiple Spark contexts per JVM (even if not running concurrently),
and while one solution is to fork a new JVM per test class, it's not always possible or desirable
to do this - if for example the test suite has a dataflow test per test method, or the test
suite has many very small tests.

This JIRA has more background and discussion about the JVM limitation:

https://issues.apache.org/jira/browse/SPARK-2243

This change makes it possible to share a SparkContext when running tests that use the
SparkPipelineRunner by setting the system property 'dataflow.spark.test.reuseSparkContext'
to 'true'.