### PR TITLE
Large broadcasts

### DIFF
--- a/src/main/java/com/cloudera/dataflow/spark/BroadcastHelper.java
+++ b/src/main/java/com/cloudera/dataflow/spark/BroadcastHelper.java
@@ -25,39 +25,93 @@ import org.apache.spark.broadcast.Broadcast;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class BroadcastHelper<T> implements Serializable {
+abstract class BroadcastHelper<T> implements Serializable {
+
+  /**
+   * If the property <code>dataflow.spark.directBroadcast</code> is set to
+   * <code>true</code> then Spark serialization (Kryo) will be used to broadcast values
+   * in View objects. By default this property is not set, and values are coded using
+   * the appropriate {@link com.google.cloud.dataflow.sdk.coders.Coder}.
+   */
+  public static final String DIRECT_BROADCAST = "dataflow.spark.directBroadcast";
 
   private static final Logger LOG = LoggerFactory.getLogger(BroadcastHelper.class);
 
-  private Broadcast<byte[]> bcast;
-  private final Coder<T> coder;
-  private transient T value;
-
-  BroadcastHelper(T value, Coder<T> coder) {
-    this.value = value;
-    this.coder = coder;
-  }
-
-  public synchronized T getValue() {
-    if (value == null) {
-      value = deserialize();
+  public static <T> BroadcastHelper<T> create(T value, Coder<T> coder) {
+    if (Boolean.getBoolean(DIRECT_BROADCAST)) {
+      return new DirectBroadcastHelper<>(value);
     }
-    return value;
+    return new CodedBroadcastHelper<>(value, coder);
   }
 
-  public void broadcast(JavaSparkContext jsc) {
-    this.bcast = jsc.broadcast(CoderHelpers.toByteArray(value, coder));
-  }
+  public abstract T getValue();
 
-  private T deserialize() {
-    T val;
-    try {
-      val = coder.decode(new ByteArrayInputStream(bcast.value()), new Coder.Context(true));
-    } catch (IOException ioe) {
-      // this should not ever happen, log it if it does.
-      LOG.warn(ioe.getMessage());
-      val = null;
+  public abstract void broadcast(JavaSparkContext jsc);
+
+  /**
+   * A {@link com.cloudera.dataflow.spark.BroadcastHelper} that relies on the underlying
+   * Spark serialization (Kryo) to broadcast values. This is appropriate when
+   * broadcasting very large values, since no copy of the object is made.
+   * @param <T>
+   */
+  static class DirectBroadcastHelper<T> extends BroadcastHelper<T> {
+    private Broadcast<T> bcast;
+    private transient T value;
+
+    DirectBroadcastHelper(T value) {
+      this.value = value;
     }
-    return val;
+
+    public synchronized T getValue() {
+      if (value == null) {
+        value = bcast.getValue();
+      }
+      return value;
+    }
+
+    public void broadcast(JavaSparkContext jsc) {
+      this.bcast = jsc.broadcast(value);
+    }
+  }
+
+  /**
+   * A {@link com.cloudera.dataflow.spark.BroadcastHelper} that uses a
+   * {@link com.google.cloud.dataflow.sdk.coders.Coder} to encode values as byte arrays
+   * before broadcasting.
+   * @param <T>
+   */
+  static class CodedBroadcastHelper<T> extends BroadcastHelper<T> {
+    private Broadcast<byte[]> bcast;
+    private final Coder<T> coder;
+    private transient T value;
+
+    CodedBroadcastHelper(T value, Coder<T> coder) {
+      this.value = value;
+      this.coder = coder;
+    }
+
+    public synchronized T getValue() {
+      if (value == null) {
+        value = deserialize();
+      }
+      return value;
+    }
+
+    public void broadcast(JavaSparkContext jsc) {
+      this.bcast = jsc.broadcast(CoderHelpers.toByteArray(value, coder));
+    }
+
+    private T deserialize() {
+      T val;
+      try {
+        val = coder.decode(new ByteArrayInputStream(bcast.value()),
+            new Coder.Context(true));
+      } catch (IOException ioe) {
+        // this should not ever happen, log it if it does.
+        LOG.warn(ioe.getMessage());
+        val = null;
+      }
+      return val;
+    }
   }
 }

--- a/src/main/java/com/cloudera/dataflow/spark/BroadcastHelper.java
+++ b/src/main/java/com/cloudera/dataflow/spark/BroadcastHelper.java
@@ -38,7 +38,7 @@ abstract class BroadcastHelper<T> implements Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(BroadcastHelper.class);
 
   public static <T> BroadcastHelper<T> create(T value, Coder<T> coder) {
-    if (Boolean.getBoolean(DIRECT_BROADCAST)) {
+    if (Boolean.parseBoolean(System.getProperty(DIRECT_BROADCAST, "false"))) {
       return new DirectBroadcastHelper<>(value);
     }
     return new CodedBroadcastHelper<>(value, coder);

--- a/src/main/java/com/cloudera/dataflow/spark/EvaluationContext.java
+++ b/src/main/java/com/cloudera/dataflow/spark/EvaluationContext.java
@@ -51,8 +51,8 @@ public class EvaluationContext implements EvaluationResult {
   private final Pipeline pipeline;
   private final SparkRuntimeContext runtime;
   private final CoderRegistry registry;
-  private final Map<PValue, JavaRDDLike<?, ?>> rdds = new LinkedHashMap<>();
-  private final Set<JavaRDDLike<?, ?>> leafRdds = new LinkedHashSet<>();
+  private final Map<PValue, RDDHolder<?>> pcollections = new LinkedHashMap<>();
+  private final Set<RDDHolder<?>> leafRdds = new LinkedHashSet<>();
   private final Set<PValue> multireads = new LinkedHashSet<>();
   private final Map<PValue, Object> pobjects = new LinkedHashMap<>();
   private final Map<PValue, Iterable<WindowedValue<?>>> pview = new LinkedHashMap<>();
@@ -63,6 +63,52 @@ public class EvaluationContext implements EvaluationResult {
     this.pipeline = pipeline;
     this.registry = pipeline.getCoderRegistry();
     this.runtime = new SparkRuntimeContext(jsc, pipeline);
+  }
+
+  /**
+   * Holds an RDD or values for deferred conversion to an RDD if needed. PCollections are
+   * sometimes created from a collection of objects (using RDD parallelize) and then
+   * only used to create View objects; in which case they do not need to be
+   * converted to bytes since they are not transferred across the network until they are
+   * broadcast.
+   */
+  private class RDDHolder<T> {
+
+    private Iterable<T> values;
+    private Coder<T> coder;
+    private JavaRDDLike<T, ?> rdd;
+
+    public RDDHolder(Iterable<T> values, Coder<T> coder) {
+      this.values = values;
+      this.coder = coder;
+    }
+
+    public RDDHolder(JavaRDDLike<T, ?> rdd) {
+      this.rdd = rdd;
+    }
+
+    public JavaRDDLike<T, ?> getRDD() {
+      if (rdd == null) {
+        rdd = jsc.parallelize(CoderHelpers.toByteArrays(values, coder))
+            .map(CoderHelpers.fromByteFunction(coder));
+      }
+      return rdd;
+    }
+
+    public Iterable<T> getValues(PCollection<T> pcollection) {
+      if (values == null) {
+        coder = pcollection.getCoder();
+        JavaRDDLike<byte[], ?> bytesRDD = rdd.map(CoderHelpers.toByteFunction(coder));
+        List<byte[]> clientBytes = bytesRDD.collect();
+        values = Iterables.transform(clientBytes, new Function<byte[], T>() {
+          @Override
+          public T apply(byte[] bytes) {
+            return CoderHelpers.fromByteArray(bytes, coder);
+          }
+        });
+      }
+      return values;
+    }
   }
 
   JavaSparkContext getSparkContext() {
@@ -97,8 +143,13 @@ public class EvaluationContext implements EvaluationResult {
     return output;
   }
 
-  void setOutputRDD(PTransform<?, ?> transform, JavaRDDLike<?, ?> rdd) {
+  <T> void setOutputRDD(PTransform<?, ?> transform, JavaRDDLike<T, ?> rdd) {
     setRDD((PValue) getOutput(transform), rdd);
+  }
+
+  <T> void setOutputRDDFromValues(PTransform<?, ?> transform, Iterable<T> values,
+      Coder<T> coder) {
+    pcollections.put((PValue) getOutput(transform), new RDDHolder<>(values, coder));
   }
 
   void setPView(PValue view, Iterable<WindowedValue<?>> value) {
@@ -106,8 +157,9 @@ public class EvaluationContext implements EvaluationResult {
   }
 
   JavaRDDLike<?, ?> getRDD(PValue pvalue) {
-    JavaRDDLike<?, ?> rdd = rdds.get(pvalue);
-    leafRdds.remove(rdd);
+    RDDHolder<?> rddHolder = pcollections.get(pvalue);
+    JavaRDDLike<?, ?> rdd = rddHolder.getRDD();
+    leafRdds.remove(rddHolder);
     if (multireads.contains(pvalue)) {
       // Ensure the RDD is marked as cached
       rdd.rdd().cache();
@@ -117,14 +169,15 @@ public class EvaluationContext implements EvaluationResult {
     return rdd;
   }
 
-  void setRDD(PValue pvalue, JavaRDDLike<?, ?> rdd) {
+  <T> void setRDD(PValue pvalue, JavaRDDLike<T, ?> rdd) {
     try {
       rdd.rdd().setName(pvalue.getName());
     } catch (IllegalStateException e) {
       // name not set, ignore
     }
-    rdds.put(pvalue, rdd);
-    leafRdds.add(rdd);
+    RDDHolder<T> rddHolder = new RDDHolder<>(rdd);
+    pcollections.put(pvalue, rddHolder);
+    leafRdds.add(rddHolder);
   }
 
   JavaRDDLike<?, ?> getInputRDD(PTransform transform) {
@@ -142,7 +195,8 @@ public class EvaluationContext implements EvaluationResult {
    * effects).
    */
   void computeOutputs() {
-    for (JavaRDDLike<?, ?> rdd : leafRdds) {
+    for (RDDHolder<?> rddHolder : leafRdds) {
+      JavaRDDLike<?, ?> rdd = rddHolder.getRDD();
       rdd.rdd().cache(); // cache so that any subsequent get() is cheap
       rdd.count(); // force the RDD to be computed
     }
@@ -155,8 +209,8 @@ public class EvaluationContext implements EvaluationResult {
       T result = (T) pobjects.get(value);
       return result;
     }
-    if (rdds.containsKey(value)) {
-      JavaRDDLike<?, ?> rdd = rdds.get(value);
+    if (pcollections.containsKey(value)) {
+      JavaRDDLike<?, ?> rdd = pcollections.get(value).getRDD();
       @SuppressWarnings("unchecked")
       T res = (T) Iterables.getOnlyElement(rdd.collect());
       pobjects.put(value, res);
@@ -179,18 +233,8 @@ public class EvaluationContext implements EvaluationResult {
   @Override
   public <T> Iterable<T> get(PCollection<T> pcollection) {
     @SuppressWarnings("unchecked")
-    JavaRDDLike<T, ?> rdd = (JavaRDDLike<T, ?>) getRDD(pcollection);
-    // Use a coder to convert the objects in the PCollection to byte arrays, so they
-    // can be transferred over the network.
-    final Coder<T> coder = pcollection.getCoder();
-    JavaRDDLike<byte[], ?> bytesRDD = rdd.map(CoderHelpers.toByteFunction(coder));
-    List<byte[]> clientBytes = bytesRDD.collect();
-    return Iterables.transform(clientBytes, new Function<byte[], T>() {
-      @Override
-      public T apply(byte[] bytes) {
-        return CoderHelpers.fromByteArray(bytes, coder);
-      }
-    });
+    RDDHolder<T> rddHolder = (RDDHolder<T>) pcollections.get(pcollection);
+    return rddHolder.getValues(pcollection);
   }
 
   @Override

--- a/src/main/java/com/cloudera/dataflow/spark/TransformTranslator.java
+++ b/src/main/java/com/cloudera/dataflow/spark/TransformTranslator.java
@@ -528,9 +528,7 @@ public final class TransformTranslator {
         // Use a coder to convert the objects in the PCollection to byte arrays, so they
         // can be transferred over the network.
         Coder<T> coder = context.getOutput(transform).getCoder();
-        JavaRDD<byte[]> rdd = context.getSparkContext().parallelize(
-            CoderHelpers.toByteArrays(elems, coder));
-        context.setOutputRDD(transform, rdd.map(CoderHelpers.fromByteFunction(coder)));
+        context.setOutputRDDFromValues(transform, elems, coder);
       }
     };
   }

--- a/src/main/java/com/cloudera/dataflow/spark/TransformTranslator.java
+++ b/src/main/java/com/cloudera/dataflow/spark/TransformTranslator.java
@@ -599,7 +599,7 @@ public final class TransformTranslator {
       for (PCollectionView<?> view : views) {
         Iterable<WindowedValue<?>> collectionView = context.getPCollectionView(view);
         Coder<Iterable<WindowedValue<?>>> coderInternal = view.getCoderInternal();
-        BroadcastHelper<?> helper = new BroadcastHelper<>(collectionView, coderInternal);
+        BroadcastHelper<?> helper = BroadcastHelper.create(collectionView, coderInternal);
         //broadcast side inputs
         helper.broadcast(context.getSparkContext());
         sideInputs.put(view.getTagInternal(), helper);


### PR DESCRIPTION
The is an improvement to reduce the number of copies made of objects when serializing them to bytes[] for transmission across the network. 

The first is to avoid eagerly parallelizing a PCollection from values that have been turned into byte arrays, since in some cases - notably when creating views - this is not needed.

The second is to allow boradcasts to be made of values themselves, rather than their byte array equivalents.

With these changes I was able to successfully use a view that was ~3GB in size. Before these changes it ran out of memory since two copies were being made.