### PR TITLE
Expose pipeline results as a RDD.

### DIFF
--- a/src/main/java/com/cloudera/dataflow/spark/EvaluationContext.java
+++ b/src/main/java/com/cloudera/dataflow/spark/EvaluationContext.java
@@ -238,6 +238,13 @@ public class EvaluationContext implements EvaluationResult {
   }
 
   @Override
+  public <T> JavaRDDLike<T, ?> asRDD(PCollection<T> pcollection) {
+    @SuppressWarnings("unchecked")
+    RDDHolder<T> rddHolder = (RDDHolder<T>) pcollections.get(pcollection);
+    return rddHolder.getRDD();
+  }
+
+  @Override
   public void close() {
     SparkContextFactory.stopSparkContext(jsc);
   }

--- a/src/main/java/com/cloudera/dataflow/spark/EvaluationResult.java
+++ b/src/main/java/com/cloudera/dataflow/spark/EvaluationResult.java
@@ -18,6 +18,7 @@ package com.cloudera.dataflow.spark;
 import com.google.cloud.dataflow.sdk.PipelineResult;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.dataflow.sdk.values.PValue;
+import org.apache.spark.api.java.JavaRDDLike;
 
 /**
  * Interface for retrieving the result(s) of running a pipeline. Allows us to translate between
@@ -51,6 +52,15 @@ public interface EvaluationResult extends PipelineResult {
    * @return Result of aggregation associated with specified name.
    */
   <T> T getAggregatorValue(String aggName, Class<T> resultType);
+
+  /**
+   * Retrieves a Spark RDD associated with the PCollection passed in.
+   *
+   * @param pcollection Collection we wish to translate.
+   * @param <T>         Type of elements contained in collection.
+   * @return Spark RDD associated with collection.
+   */
+  <T> JavaRDDLike<T, ?> asRDD(PCollection<T> pcollection);
 
   /**
    * Releases any runtime resources, including distributed-execution contexts currently held by


### PR DESCRIPTION
This shows what the interface changes for https://github.com/cloudera/spark-dataflow/issues/65 look like.

Not ready to be merged as it needs a test.