### PR TITLE
Add support for writes with HadoopIO

### DIFF
--- a/build-resources/checkstyle.xml
+++ b/build-resources/checkstyle.xml
@@ -115,7 +115,9 @@
             <property name="max" value="100"/>
         </module>
         <module name="MethodLength"/>
-        <module name="ParameterNumber"/>
+        <module name="ParameterNumber">
+          <property name="max" value="8"/>
+        </module>
         <module name="OuterTypeNumber"/>
 
         <!-- Checks for whitespace                               -->
@@ -180,7 +182,7 @@
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>
         <module name="MissingSwitchDefault"/>
-        <module name="RedundantThrows"/>
+        <!--<module name="RedundantThrows"/>-->
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
         <module name="DefaultComesLast"/>

--- a/src/main/java/com/cloudera/dataflow/hadoop/HadoopIO.java
+++ b/src/main/java/com/cloudera/dataflow/hadoop/HadoopIO.java
@@ -14,13 +14,21 @@
  */
 package com.cloudera.dataflow.hadoop;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.cloud.dataflow.sdk.io.ShardNameTemplate;
 import com.google.cloud.dataflow.sdk.transforms.PTransform;
 import com.google.cloud.dataflow.sdk.util.WindowingStrategy;
 import com.google.cloud.dataflow.sdk.values.KV;
 import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.dataflow.sdk.values.PDone;
 import com.google.cloud.dataflow.sdk.values.PInput;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+
+import com.cloudera.dataflow.spark.ShardNameTemplateAware;
 
 public final class HadoopIO {
 
@@ -84,5 +92,111 @@ public final class HadoopIO {
 
     }
 
+  }
+
+  public static final class Write {
+
+    private Write() {
+    }
+
+    public static <K, V> Bound to(String filenamePrefix,
+        Class<? extends FileOutputFormat<K, V>> format, Class<K> key, Class<V> value) {
+      return new Bound<>(filenamePrefix, format, key, value);
+    }
+
+    public static class Bound<K, V> extends PTransform<PCollection<KV<K, V>>, PDone> {
+
+      /** The filename to write to. */
+      private final String filenamePrefix;
+      /** Suffix to use for each filename. */
+      private final String filenameSuffix;
+      /** Requested number of shards.  0 for automatic. */
+      private final int numShards;
+      /** Shard template string. */
+      private final String shardTemplate;
+      private final Class<? extends FileOutputFormat<K, V>> formatClass;
+      private final Class<K> keyClass;
+      private final Class<V> valueClass;
+      private final Map<String, String> configurationProperties;
+
+      Bound(String filenamePrefix, Class<? extends FileOutputFormat<K, V>> format,
+          Class<K> key,
+          Class<V> value) {
+        this(filenamePrefix, "", 0, ShardNameTemplate.INDEX_OF_MAX, format, key, value,
+            new HashMap<String, String>());
+      }
+
+      Bound(String filenamePrefix, String filenameSuffix, int numShards,
+          String shardTemplate, Class<? extends FileOutputFormat<K, V>> format,
+          Class<K> key, Class<V> value, Map<String, String> configurationProperties) {
+        this.filenamePrefix = filenamePrefix;
+        this.filenameSuffix = filenameSuffix;
+        this.numShards = numShards;
+        this.shardTemplate = shardTemplate;
+        this.formatClass = format;
+        this.keyClass = key;
+        this.valueClass = value;
+        this.configurationProperties = configurationProperties;
+      }
+
+      public Bound<K, V> withoutSharding() {
+        return new Bound<>(filenamePrefix, filenameSuffix, 1, "", formatClass,
+            keyClass, valueClass, configurationProperties);
+      }
+
+      public Bound<K, V> withConfigurationProperty(String key, String value) {
+        configurationProperties.put(key, value);
+        return this;
+      }
+
+      public String getFilenamePrefix() {
+        return filenamePrefix;
+      }
+
+      public String getShardTemplate() {
+        return shardTemplate;
+      }
+
+      public int getNumShards() {
+        return numShards;
+      }
+
+      public String getFilenameSuffix() {
+        return filenameSuffix;
+      }
+
+      public Class<? extends FileOutputFormat<K, V>> getFormatClass() {
+        return formatClass;
+      }
+
+      public Class<V> getValueClass() {
+        return valueClass;
+      }
+
+      public Class<K> getKeyClass() {
+        return keyClass;
+      }
+
+      public Map<String, String> getConfigurationProperties() {
+        return configurationProperties;
+      }
+
+      @Override
+      public PDone apply(PCollection<KV<K, V>> input) {
+        Preconditions.checkNotNull(filenamePrefix,
+            "need to set the filename prefix of an HadoopIO.Write transform");
+        Preconditions.checkNotNull(formatClass,
+            "need to set the format class of an HadoopIO.Write transform");
+        Preconditions.checkNotNull(keyClass,
+            "need to set the key class of an HadoopIO.Write transform");
+        Preconditions.checkNotNull(valueClass,
+            "need to set the value class of an HadoopIO.Write transform");
+
+        Preconditions.checkArgument(ShardNameTemplateAware.class.isAssignableFrom(formatClass),
+            "Format class must implement " + ShardNameTemplateAware.class.getName());
+
+        return PDone.in(input.getPipeline());
+      }
+    }
   }
 }

--- a/src/main/java/com/cloudera/dataflow/hadoop/WritableCoder.java
+++ b/src/main/java/com/cloudera/dataflow/hadoop/WritableCoder.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.cloudera.dataflow.hadoop;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.cloud.dataflow.sdk.coders.Coder;
+import com.google.cloud.dataflow.sdk.coders.CoderException;
+import com.google.cloud.dataflow.sdk.coders.StandardCoder;
+import com.google.cloud.dataflow.sdk.util.CloudObject;
+import org.apache.hadoop.io.Writable;
+
+/**
+ * A {@code WritableCoder} is a {@link com.google.cloud.dataflow.sdk.coders.Coder} for a
+ * Java class that implements {@link org.apache.hadoop.io.Writable}.
+ *
+ * <p> To use, specify the coder type on a PCollection:
+ * <pre>
+ * {@code
+ *   PCollection<MyRecord> records =
+ *       foo.apply(...).setCoder(WritableCoder.of(MyRecord.class));
+ * }
+ * </pre>
+ *
+ * @param <T> the type of elements handled by this coder
+ */
+public class WritableCoder<T extends Writable> extends StandardCoder<T> {
+  private static final long serialVersionUID = 0L;
+
+  /**
+   * Returns a {@code WritableCoder} instance for the provided element class.
+   * @param <T> the element type
+   * @param clazz the element class
+   * @return a {@code WritableCoder} instance for the provided element class
+   */
+  public static <T extends Writable> WritableCoder<T> of(Class<T> clazz) {
+    return new WritableCoder<>(clazz);
+  }
+
+  @JsonCreator
+  @SuppressWarnings("unchecked")
+  public static WritableCoder<?> of(@JsonProperty("type") String classType)
+      throws ClassNotFoundException {
+    Class<?> clazz = Class.forName(classType);
+    if (!Writable.class.isAssignableFrom(clazz)) {
+      throw new ClassNotFoundException(
+          "Class " + classType + " does not implement Writable");
+    }
+    return of((Class<? extends Writable>) clazz);
+  }
+
+  private final Class<T> type;
+
+  public WritableCoder(Class<T> type) {
+    this.type = type;
+  }
+
+  @Override
+  public void encode(T value, OutputStream outStream, Context context) throws IOException {
+    value.write(new DataOutputStream(outStream));
+  }
+
+  @Override
+  public T decode(InputStream inStream, Context context) throws IOException {
+    try {
+      T t = type.newInstance();
+      t.readFields(new DataInputStream(inStream));
+      return t;
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new CoderException("unable to deserialize record", e);
+    }
+  }
+
+  @Override
+  public List<Coder<?>> getCoderArguments() {
+    return null;
+  }
+
+  @Override
+  public CloudObject asCloudObject() {
+    CloudObject result = super.asCloudObject();
+    result.put("type", type.getName());
+    return result;
+  }
+
+  @Override
+  public void verifyDeterministic() throws Coder.NonDeterministicException {
+    throw new NonDeterministicException(this,
+        "Hadoop Writable may be non-deterministic.");
+  }
+
+}

--- a/src/main/java/com/cloudera/dataflow/spark/ShardNameTemplateAware.java
+++ b/src/main/java/com/cloudera/dataflow/spark/ShardNameTemplateAware.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.cloudera.dataflow.spark;
+
+/**
+ * A marker interface that implementations of
+ * {@link org.apache.hadoop.mapreduce.lib.output.FileOutputFormat} implement to indicate
+ * that they produce shard names that adhere to the template in
+ * {@link com.cloudera.dataflow.hadoop.HadoopIO.Write}.
+ *
+ * Some common shard names are defined in
+ * {@link com.google.cloud.dataflow.sdk.io.ShardNameTemplate}.
+ */
+public interface ShardNameTemplateAware {
+}

--- a/src/main/java/com/cloudera/dataflow/spark/ShardNameTemplateHelper.java
+++ b/src/main/java/com/cloudera/dataflow/spark/ShardNameTemplateHelper.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.cloudera.dataflow.spark;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskID;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.cloudera.dataflow.spark.ShardNameBuilder.replaceShardNumber;
+
+public final class ShardNameTemplateHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ShardNameTemplateHelper.class);
+
+  public static final String OUTPUT_FILE_PREFIX = "spark.dataflow.fileoutputformat.prefix";
+  public static final String OUTPUT_FILE_TEMPLATE = "spark.dataflow.fileoutputformat.template";
+  public static final String OUTPUT_FILE_SUFFIX = "spark.dataflow.fileoutputformat.suffix";
+
+  private ShardNameTemplateHelper() {
+  }
+
+  public static <K, V> Path getDefaultWorkFile(FileOutputFormat<K, V> format,
+      TaskAttemptContext context) throws IOException {
+    FileOutputCommitter committer =
+        (FileOutputCommitter) format.getOutputCommitter(context);
+    return new Path(committer.getWorkPath(), getOutputFile(context));
+  }
+
+  private static String getOutputFile(TaskAttemptContext context) {
+    TaskID taskId = context.getTaskAttemptID().getTaskID();
+    int partition = taskId.getId();
+
+    String filePrefix = context.getConfiguration().get(OUTPUT_FILE_PREFIX);
+    String fileTemplate = context.getConfiguration().get(OUTPUT_FILE_TEMPLATE);
+    String fileSuffix = context.getConfiguration().get(OUTPUT_FILE_SUFFIX);
+    return filePrefix + replaceShardNumber(fileTemplate, partition) + fileSuffix;
+  }
+
+}

--- a/src/main/java/com/cloudera/dataflow/spark/TemplatedAvroKeyOutputFormat.java
+++ b/src/main/java/com/cloudera/dataflow/spark/TemplatedAvroKeyOutputFormat.java
@@ -16,13 +16,14 @@
 package com.cloudera.dataflow.spark;
 
 import java.io.IOException;
+import java.io.OutputStream;
 
+import org.apache.avro.mapreduce.AvroKeyOutputFormat;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 
-public class TemplatedTextOutputFormat<K, V> extends TextOutputFormat<K, V>
+public class TemplatedAvroKeyOutputFormat<T> extends AvroKeyOutputFormat<T>
     implements ShardNameTemplateAware {
 
   @Override
@@ -31,10 +32,9 @@ public class TemplatedTextOutputFormat<K, V> extends TextOutputFormat<K, V>
   }
 
   @Override
-  public Path getDefaultWorkFile(TaskAttemptContext context,
-      String extension) throws IOException {
-    // note that the passed-in extension is ignored since it comes from the template
-    return ShardNameTemplateHelper.getDefaultWorkFile(this, context);
+  protected OutputStream getAvroFileOutputStream(TaskAttemptContext context) throws IOException {
+    Path path = ShardNameTemplateHelper.getDefaultWorkFile(this, context);
+    return path.getFileSystem(context.getConfiguration()).create(path);
   }
 
 }

--- a/src/main/java/com/cloudera/dataflow/spark/TemplatedSequenceFileOutputFormat.java
+++ b/src/main/java/com/cloudera/dataflow/spark/TemplatedSequenceFileOutputFormat.java
@@ -20,9 +20,9 @@ import java.io.IOException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+import org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat;
 
-public class TemplatedTextOutputFormat<K, V> extends TextOutputFormat<K, V>
+public class TemplatedSequenceFileOutputFormat<K, V> extends SequenceFileOutputFormat<K, V>
     implements ShardNameTemplateAware {
 
   @Override

--- a/src/test/java/com/cloudera/dataflow/spark/AvroPipelineTest.java
+++ b/src/test/java/com/cloudera/dataflow/spark/AvroPipelineTest.java
@@ -90,8 +90,8 @@ public class AvroPipelineTest {
   private List<GenericRecord> readGenericFile() throws IOException {
     List<GenericRecord> records = Lists.newArrayList();
     GenericDatumReader<GenericRecord> genericDatumReader = new GenericDatumReader<>();
-    try (DataFileReader<GenericRecord> dataFileReader = new DataFileReader<>
-        (new File(outputDir, "part-r-00000.avro"), genericDatumReader)) {
+    try (DataFileReader<GenericRecord> dataFileReader =
+             new DataFileReader<>(new File(outputDir + "-00000-of-00001"), genericDatumReader)) {
       for (GenericRecord record : dataFileReader) {
         records.add(record);
       }


### PR DESCRIPTION
This allows Hadoop FileOutputFormats to be used with Spark Dataflow, as long as they
implement the ShardNameTemplateAware interface. This is easily achieved
by subclassing the desired FileOutputFormat class, see
TemplatedSequenceFileOutputFormat for an example.