### PR TITLE
Correct input parameter is --inputFile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@ License.
                             <argument>-classpath</argument>
                             <classpath />
                             <argument>${mainClass}</argument>
-                            <argument>--input=${input}</argument>
+                            <argument>--inputFile=${input}</argument>
                             <argument>--output=${output}</argument>
                             <argument>--runner=${runner}</argument>
                             <argument>--sparkMaster=${sparkMaster}</argument>


### PR DESCRIPTION
I tried to follow the README to run the Word Count Example and I noticed that in com.google.cloud.dataflow.examples.WordCount it is mentioned that the input file can be overridden with --inputFile. Works for local run. 