### PR TITLE
Propagate user exceptions thrown in DoFns.

### DIFF
--- a/src/main/java/com/cloudera/dataflow/spark/SparkProcessContext.java
+++ b/src/main/java/com/cloudera/dataflow/spark/SparkProcessContext.java
@@ -212,7 +212,7 @@ abstract class SparkProcessContext<I, O, V> extends DoFn<I, O>.ProcessContext {
           try {
             doFn.processElement(SparkProcessContext.this);
           } catch (Exception e) {
-            throw new IllegalStateException(e);
+            throw new SparkProcessException(e);
           }
           outputIterator = getOutputIterator();
         } else {
@@ -223,7 +223,7 @@ abstract class SparkProcessContext<I, O, V> extends DoFn<I, O>.ProcessContext {
               calledFinish = true;
               doFn.finishBundle(SparkProcessContext.this);
             } catch (Exception e) {
-              throw new IllegalStateException(e);
+              throw new SparkProcessException(e);
             }
             outputIterator = getOutputIterator();
             continue; // try to consume outputIterator from start of loop
@@ -231,6 +231,12 @@ abstract class SparkProcessContext<I, O, V> extends DoFn<I, O>.ProcessContext {
           return endOfData();
         }
       }
+    }
+  }
+
+  static class SparkProcessException extends RuntimeException {
+    public SparkProcessException(Throwable t) {
+      super(t);
     }
   }
 


### PR DESCRIPTION
Support was added in Spark 1.5.0 for user exception propagation,
see https://issues.apache.org/jira/browse/SPARK-8625.

Fixes https://github.com/cloudera/spark-dataflow/issues/69